### PR TITLE
fixing the messages

### DIFF
--- a/checkers/Move.java
+++ b/checkers/Move.java
@@ -52,17 +52,18 @@ public class Move {
             return false;
         }
 
+        // Check if the starting piece is a 0
+        if (startingPiece.value == 0) {
+            System.out.println("\nThere is no piece at that location!\n");
+            return false;
+        }
+
         // Check player's turn
         if (startingPiece.value != player) {
             System.out.println("It's " + (player == 1 ? "black" : "white") + "'s turn!");
             return false;
         }
 
-        // Check if the starting piece is a 0
-        if (startingPiece.value == 0) {
-            System.out.println("\nThere is no piece at that location!\n");
-            return false;
-        }
 
         // Check if the ending piece is a 0
         if (endingPiece.value != 0) {


### PR DESCRIPTION
If a player tries to play from a spot that does not have a piece the message that is printed is "It's black's turn", if it's black's turn or "It's white's turn" otherwise, while it should print "There is no piece at that location!". That's because the first "if" condition that is checked is the one that checks if it's the turn of the player that requested the move and not the one that checks if there is or there is not a piece at this location.
Let's take for example at the first move of the game and try to play: F-2 > E-1. The message will be "It's black's turn" as shown in
the pictures. After the change of the functions it will print "There is no piece at that location!" which is the right message.
So we have to change the sequence of the "if" conditions.

![Wrong_message](https://user-images.githubusercontent.com/74017491/218546145-285ba9ea-ed2c-4c2a-a987-21c34cc39246.png)
![Correct_message](https://user-images.githubusercontent.com/74017491/218546162-f17a3ead-e48b-42e1-90fc-0cc72b1e9478.png)
